### PR TITLE
feat(csv): CSV template (BOM UTF-8 + CRLF) + HEAD

### DIFF
--- a/app/dpi_csv.py
+++ b/app/dpi_csv.py
@@ -1,0 +1,45 @@
+﻿from fastapi import APIRouter, Response
+from fastapi.responses import StreamingResponse
+import io, csv, codecs
+
+router = APIRouter()
+
+def _template_bytes() -> bytes:
+    # StringIO con newline='' + lineterminator='\r\n' per CRLF
+    buf = io.StringIO(newline='')
+    w = csv.writer(buf, lineterminator='\r\n')
+    headers = [
+        "codice","descrizione","marca","modello","matricola",
+        "assegnato_a","data_inizio","data_fine","certificazione","scadenza","note"
+    ]
+    w.writerow(headers)
+    data = buf.getvalue().encode("utf-8")           # senza BOM
+    return codecs.BOM_UTF8 + data                    # aggiungo BOM
+
+@router.get(
+    "/api/dpi/csv/template",
+    summary="CSV template for DPI import",
+    responses={
+        200: {
+            "description": "CSV file",
+            "content": {"text/csv": {"schema": {"type": "string", "format": "binary"}}},
+        }
+    },
+)
+def csv_template_get():
+    headers = {
+        "Content-Disposition": 'attachment; filename="dpi_template.csv"',
+        "Cache-Control": "no-store",
+    }
+    # streaming per evitare bufferoni in memoria
+    return StreamingResponse(iter([_template_bytes()]), media_type="text/csv; charset=utf-8", headers=headers)
+
+@router.head("/api/dpi/csv/template", summary="HEAD for CSV template")
+def csv_template_head():
+    # stesse intestazioni del GET, senza body
+    headers = {
+        "Content-Type": "text/csv; charset=utf-8",
+        "Content-Disposition": 'attachment; filename="dpi_template.csv"',
+        "Cache-Control": "no-store",
+    }
+    return Response(status_code=200, headers=headers)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,4 @@
+﻿
+from .dpi_csv import router as csv_router
+app.include_router(csv_router)
+


### PR DESCRIPTION
## Contesto
Aggiunge endpoint “CSV template” per import DPI e HEAD companion. Scopo: fornire un CSV “sicuro” per Excel/Import (BOM UTF-8, terminatori CRLF, download come attachment) e documentazione automatica in /docs.

## Cosa cambia
- `app/dpi_csv.py`: nuovo router FastAPI con:
  - `GET /api/dpi/csv/template` → `text/csv; charset=utf-8`, **BOM UTF-8** (`EF BB BF`), **CRLF** per ogni riga, `Content-Disposition: attachment; filename="dpi_template.csv"`.
  - `HEAD /api/dpi/csv/template` → stesse intestazioni, nessun body.
- `app/main.py`: mount router (`app.include_router(csv_router)`).

## Perché così
- BOM evita problemi di encoding con Excel/Windows.
- CRLF nativo su Windows evita “tutto-in-una-riga” in alcuni tool legacy.
- `StreamingResponse` per non bufferizzare file (pronto per futuri CSV grandi).

## Test manuale (rapidi)
**Avvia API**
- Windows: `powershell -File scripts\Start-TPI.ps1 -AppDir . -Port 8010`
- Linux/Mac: `bash scripts/start-api.sh`

**Verifica GET**
```powershell
# scarica e mostra headers
curl -s -D - http://127.0.0.1:8010/api/dpi/csv/template -o dpi_template.csv
# BOM atteso (EF BB BF)
$first3 = (Get-Content .\dpi_template.csv -Encoding Byte -TotalCount 3); $first3
# CRLF atteso (0D 0A)
Format-Hex dpi_template.csv | Select-String "0d 0a" | Select -First 1
